### PR TITLE
fix: remove extra newline characters added to the console/terminal output

### DIFF
--- a/testing/mod.ts
+++ b/testing/mod.ts
@@ -106,7 +106,7 @@ async function runScript<TOutput>(
     write(chunk: Uint8Array) {
       const text = new TextDecoder().decode(chunk)
       if (displayStdout) {
-        console.log(text)
+        console.log(text.slice(0, -1)) // remove extra new line added by writable stream
       }
 
       accumulatedOutput += text
@@ -117,7 +117,7 @@ async function runScript<TOutput>(
     write(chunk: Uint8Array) {
       const text = new TextDecoder().decode(chunk)
       if (displayStdout) {
-        console.error(text)
+        console.error(text.slice(0, -1)) // remove extra new line added by writable stream
       }
 
       accumulatedOutput += text


### PR DESCRIPTION
## Related GitHub Issues
<!-- Link to any related GitHub issues that this pull request addresses or closes. -->

## Problem
<!-- A clear description of the problem that this pull request is solving. -->

remove extra newline characters added to the console/terminal output
the stdout list we return is correct. but what we display in the console is not

## Solution
<!-- Describe the approach you took to solve the problem and the changes made in this pull request. -->

## Testing
<!-- Choose one of the below options for how you tested the code change. Include any specific setup or instructions for testing. -->
- [ ] Added automated tests. 
- [X] Manually tested. If you check this box, provide instructions for others to test, too. 

Ran test suite for this project. Inspected the console logs/terminal output and can verify, it looks as expected. 

## Notes for reviewers 
<!-- If there is any additional information you would like to share with the person reviewing this pull request, please provide it here. -->