### PR TITLE
feat: rename the environment variable used to communicate wtih user scripts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,14 +96,14 @@ export const getLatestReleaseStepInput = (): GetLatestReleaseStepInput => {
 ### Naming Conventions
 - **Functions:** `camelCase` (e.g., `runGetLatestReleaseScript`)
 - **Interfaces/Types:** `PascalCase` (e.g., `GetLatestReleaseStepInput`)
-- **Constants:** `UPPER_SNAKE_CASE` for environment variables (e.g., `DATA_FILE_PATH`)
+- **Constants:** `UPPER_SNAKE_CASE` for environment variables (e.g., `DECAF_COMM_FILE_PATH`)
 - **Private functions:** `camelCase` with `const` (e.g., `const getInput = ...`)
 - **Exported vs private:** Only export what's needed in the public API
 
 ### Error Handling
 - Use clear error messages that explain what went wrong
 - Throw errors for unrecoverable conditions
-- Example: `throw new Error("DATA_FILE_PATH environment variable is not set.")`
+- Example: `throw new Error("DECAF_COMM_FILE_PATH environment variable is not set.")`
 
 ### Functions
 - **Arrow functions:** Use `const functionName = () => {}` for private functions

--- a/main.ts
+++ b/main.ts
@@ -216,8 +216,18 @@ export const getDeployStepInput = (): DeployStepInput => {
 }
 
 const getInput = <T>(): T => {
-  const filePath = getEnv("DATA_FILE_PATH")
-  if (!filePath) throw new Error("DATA_FILE_PATH environment variable is not set.")
+  // decaf 1.0 is going to use the environment variable DECAF_COMM_FILE_PATH.
+  // pre-1.0, it will support 2 environment variables: DATA_FILE_PATH and DECAF_COMM_FILE_PATH for backward compatibility.
+  //
+  // Just support both so the SDK is ready for decaf 1.0
+  // No need to log anything to the user about this behavior because the SDK is already abstracting this env var away so
+  // they dont care, as long as they update decaf to 1.0 eventually.
+  let filePath = getEnv("DECAF_COMM_FILE_PATH")
+  if (!filePath) {
+    filePath = getEnv("DATA_FILE_PATH")
+  }
+
+  if (!filePath) throw new Error("DECAF_COMM_FILE_PATH environment variable is not set.")
   const fileContents = nodeReadFileSync(filePath, "utf-8")
   return JSON.parse(fileContents)
 }
@@ -261,7 +271,10 @@ export const setNextReleaseVersionStepOutput = (output: GetNextReleaseVersionSte
 }
 
 const setOutput = (output: GetLatestReleaseStepOutput | GetNextReleaseVersionStepOutput): void => {
-  const filePath = getEnv("DATA_FILE_PATH")
-  if (!filePath) throw new Error("DATA_FILE_PATH environment variable is not set.")
+  let filePath = getEnv("DECAF_COMM_FILE_PATH")
+  if (!filePath) {
+    filePath = getEnv("DATA_FILE_PATH")
+  }
+  if (!filePath) throw new Error("DECAF_COMM_FILE_PATH environment variable is not set.")
   nodeWriteFileSync(filePath, JSON.stringify(output))
 }

--- a/testing/mod.test.ts
+++ b/testing/mod.test.ts
@@ -458,3 +458,24 @@ Deno.test("options.extraEnvVariables can override default environment variables"
 
   assertEquals(stdout, ["custom-token-xyz"])
 })
+
+Deno.test("testing module uses DECAF_COMM_FILE_PATH for backward compatibility", async () => {
+  const scriptPath = createScript(`
+    console.log(Deno.env.get("DECAF_COMM_FILE_PATH") ? "DECAF_COMM_FILE_PATH is set" : "not set");
+    console.log(Deno.env.get("DATA_FILE_PATH") ? "DATA_FILE_PATH is set" : "not set");
+  `)
+
+  const { stdout } = await runGetLatestReleaseScript(
+    `deno run --allow-env "${scriptPath}"`,
+    {
+      gitCurrentBranch: "main",
+      gitRepoOwner: "your-github-username",
+      gitRepoName: "your-repo-name",
+      testMode: true,
+      gitCommitsCurrentBranch: [],
+      gitCommitsAllLocalBranches: {},
+    },
+  )
+
+  assertEquals(stdout, ["DECAF_COMM_FILE_PATH is set", "DATA_FILE_PATH is set"])
+})

--- a/testing/mod.ts
+++ b/testing/mod.ts
@@ -82,7 +82,10 @@ const getEnvironmentVariables = (
   return {
     INPUT_GITHUB_TOKEN: "abcd1234",
     NO_COLOR: "1", // disable color output (ansi) for easier testing. https://docs.deno.com/api/deno/~/Deno.noColor
+    // setting both of the environment variables, for backward compatibility
+    // We can drop DATA_FILE_PATH support in v1.0
     DATA_FILE_PATH: inputFilePath,
+    DECAF_COMM_FILE_PATH: inputFilePath,
     ...(options?.extraEnvVariables ?? {}),
   }
 }
@@ -93,12 +96,7 @@ async function runScript<TOutput>(
   removeAnsiCodes = true,
   displayStdout = true,
 ): Promise<{ code: number; output: TOutput | null; stdout: string[] }> {
-  const inputFilePath = env["DATA_FILE_PATH"]
-  if (!inputFilePath) {
-    throw new Error("DATA_FILE_PATH environment variable is not set.")
-  }
-
-  const inputFileContentsBeforeRun = await readFile(inputFilePath, "utf-8")
+  const inputFileContentsBeforeRun = await readFile(env["DECAF_COMM_FILE_PATH"], "utf-8")
 
   let accumulatedOutput = ""
 
@@ -138,7 +136,7 @@ async function runScript<TOutput>(
   )
   let stdout = accumulatedOutput.split("\n")
 
-  const outputFileContentsAfterRun = await readFile(inputFilePath, "utf-8")
+  const outputFileContentsAfterRun = await readFile(env["DECAF_COMM_FILE_PATH"], "utf-8")
   let output: TOutput | null = null
   if (outputFileContentsAfterRun !== inputFileContentsBeforeRun) {
     output = JSON.parse(outputFileContentsAfterRun) as TOutput


### PR DESCRIPTION
decaf is going to do a rename of the environment variable - from DATA_FILE_PATH to DECAF_COMM_FILE_PATH. learn more: https://github.com/levibostian/decaf/pull/130

this commit prepares for that change by adding support for DECAF_COMM_FILE_PATH while still keeping backwards compatible support until v1.0