### PR TITLE
feat: specify currentWorkingDirectory where to run your scripts from in testing module

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,16 @@ The test runner functions return:
 ### Available test runner functions
 
 The testing module exports the following functions:
-- `runGetLatestReleaseScript(command: string, input: GetLatestReleaseStepInput)` - Run a get latest release step script with the provided command and input data.
-- `runGetNextReleaseVersionScript(command: string, input: GetNextReleaseVersionStepInput)` - Run a get next release version step script with the provided command and input data.
-- `runDeployScript(command: string, input: DeployStepInput)` - Run a deploy step script with the provided command and input data.
+- `runGetLatestReleaseScript(command: string, input: GetLatestReleaseStepInput, options?: RunScriptOptions)` - Run a get latest release step script with the provided command and input data.
+- `runGetNextReleaseVersionScript(command: string, input: GetNextReleaseVersionStepInput, options?: RunScriptOptions)` - Run a get next release version step script with the provided command and input data.
+- `runDeployScript(command: string, input: DeployStepInput, options?: RunScriptOptions)` - Run a deploy step script with the provided command and input data.
+
+### RunScriptOptions
+
+The `RunScriptOptions` interface allows you to customize the behavior of the test runner functions. It includes the following properties:
+- `removeAnsiCodes?: boolean` - If true, ANSI codes will be removed from the script output. Default is true. This makes assertions/snapshot tests more human readable.
+- `displayStdout?: boolean` - If true, the script's stdout will be displayed in the console during the test run. Default is true.
+- `extraEnvVariables?: Record<string, string>` - Additional environment variables to pass to the script during execution. 
+- `currentWorkingDirectory?: string` - The current working directory to run the script in. This is intended to match the behavior of `current_working_directory` config option added in decaf 0.11.0
+
+


### PR DESCRIPTION
[a new config option is being added to decaf](https://github.com/levibostian/decaf/pull/131): current_working_directory. This is to add support for that new feature. 

## Related GitHub Issues
<!-- Link to any related GitHub issues that this pull request addresses or closes. -->

## Problem
<!-- A clear description of the problem that this pull request is solving. -->

## Solution
<!-- Describe the approach you took to solve the problem and the changes made in this pull request. -->

## Testing
<!-- Choose one of the below options for how you tested the code change. Include any specific setup or instructions for testing. -->
- [X] Added automated tests. 
- [X] Manually tested. If you check this box, provide instructions for others to test, too. 

I bundled the testing/mod.ts file and tested it works in the decaf PR tests. 

## Notes for reviewers 
<!-- If there is any additional information you would like to share with the person reviewing this pull request, please provide it here. -->