### PR TITLE
feat: set DECAF_ROOT_WORKING_DIRECTORY in testing module, like decaf does

### DIFF
--- a/testing/mod.ts
+++ b/testing/mod.ts
@@ -95,6 +95,8 @@ const getEnvironmentVariables = (
     // We can drop DATA_FILE_PATH support in v1.0
     DATA_FILE_PATH: inputFilePath,
     DECAF_COMM_FILE_PATH: inputFilePath,
+    // Automatically set DECAF_ROOT_WORKING_DIRECTORY to mirror production behavior
+    DECAF_ROOT_WORKING_DIRECTORY: Deno.cwd(),
     ...(options?.extraEnvVariables ?? {}),
   }
 }


### PR DESCRIPTION
## Related GitHub Issues
<!-- Link to any related GitHub issues that this pull request addresses or closes. -->

## Problem
<!-- A clear description of the problem that this pull request is solving. -->

[in v0.11.0, decaf will be adding DECAF_ROOT_WORKING_DIRECTORY env variable as a convenience to accompany `current_working_directory`](https://github.com/levibostian/decaf/pull/131). We need to update the SDK to also add this var in order for you to use that var in your script. 

## Solution
<!-- Describe the approach you took to solve the problem and the changes made in this pull request. -->

Set it, just like decaf does. 

## Testing
<!-- Choose one of the below options for how you tested the code change. Include any specific setup or instructions for testing. -->
- [X] Added automated tests. 
- [X] Manually tested. If you check this box, provide instructions for others to test, too. 

I bundled the testing module, then ran it in the decaf test suite and proved that it works. 

## Notes for reviewers 
<!-- If there is any additional information you would like to share with the person reviewing this pull request, please provide it here. -->